### PR TITLE
Fix double focus on treeview items

### DIFF
--- a/src/modules/treeview/index.js
+++ b/src/modules/treeview/index.js
@@ -84,8 +84,8 @@ const Treeview = function({
   }
 
   function _updateStyling(treeview, $item) {
-    treeview.$items.removeClass(classFocused).attr('tabindex', '-1')
-    $item.addClass(classFocused).attr('tabindex', '0')
+    treeview.$items.removeClass(classFocused)
+    $item.addClass(classFocused)
   }
 
   function _handleKeyDown(treeview, $item, e) {


### PR DESCRIPTION
Il focus per la navigazione da tastiera è già catturato dai link <a>, quindi l’aggiunta dell’attributo tabindex agli item dopo il primo click rende la navigazione non coerente.