### PR TITLE
Rimosso vendor.css

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ npm-debug.log
 styleguide
 gh-pages
 .idea
+.vscode
 build/*
 

--- a/config.js
+++ b/config.js
@@ -28,7 +28,7 @@ const CONFIG = {}
 CONFIG.includes = []
 
 /*
- *  Blacklist: use this array of RegEx to exclude specific omponents
+ *  Blacklist: use this array of RegEx to exclude specific components
  *  or modules from the final build.
  *
  *    ie. to exclude all global CSS:

--- a/docs/come-iniziare.md
+++ b/docs/come-iniziare.md
@@ -31,7 +31,6 @@ In produzione vanno inclusi almeno i file:
 ```
 .
 ├── build.css
-├── vendor.css
 ├── vendor/modernizr.js
 ├── vendor/jquery.min.js
 └── IWT.min.js

--- a/fractal.js
+++ b/fractal.js
@@ -9,7 +9,7 @@ fractal.docs.set('path', __dirname + '/docs')
 fractal.web.set('static.path', __dirname + '/build')
 
 // prefix all resources url with '/build'
-//
+
 if (process.env.DEPLOY === 'true') {
   fractal.web.set('static.mount', '/ita-web-toolkit/build')
 } else {
@@ -80,8 +80,7 @@ const myCustomisedTheme = mandelbrot({
   'styles': [
     'default',
     '/ita-web-toolkit/theme/styleguide.css',
-    '/build/build-styleguide.css',
-    '/build/vendor.css'
+    '/build/build-styleguide.css'
   ],
   'scripts': [
     'default',

--- a/src/_preview.tmpl
+++ b/src/_preview.tmpl
@@ -35,7 +35,6 @@
   <!-- include html5shim per Explorer 8 -->
   <script src="{{ '/build/vendor/modernizr.js' | path }}"></script>
 
-  <link media="all" rel="stylesheet" href="{{ '/build/vendor.css' | path }}">
   <link media="all" rel="stylesheet" href="{{ '/build/build.css' | path }}">
 
   <script src="{{ '/build/vendor/jquery.min.js' | path }}"></script>

--- a/src/modules/accordion/index.css
+++ b/src/modules/accordion/index.css
@@ -1,3 +1,5 @@
+@import "fr-accordion/accordion.css";
+
 /** @define Accordion */
 
 :root {

--- a/src/modules/accordion/index.js
+++ b/src/modules/accordion/index.js
@@ -1,11 +1,5 @@
 import Fraccordion from 'fr-accordion'
 
-/* eslint-disable no-unused-vars */
-
-import stylesheet from 'fr-accordion/accordion.css'
-
-/* eslint-enable */
-
 const accordion = Fraccordion({
 	// String - Use header id on element to tie each accordion panel to its header - see panelIdPrefix
 	headerIdPrefix: 'accordion-header',

--- a/src/modules/dialog/index.css
+++ b/src/modules/dialog/index.css
@@ -1,3 +1,5 @@
+@import "fr-dialogmodal/dialogmodal.css";
+
 /** @define Dialog; */
 
 /* postcss-bem-linter: ignore */

--- a/src/modules/dialog/index.js
+++ b/src/modules/dialog/index.js
@@ -1,11 +1,5 @@
 import Frdialogmodal from 'fr-dialogmodal/dialogmodal.js'
 
-/* eslint-disable no-unused-vars */
-
-import stylesheet from 'fr-dialogmodal/dialogmodal.css'
-
-/* eslint-enable */
-
 var dialog = Frdialogmodal({
   // String - Outer container selector, hook for JS init() method
   selector: '.js-fr-dialogmodal',

--- a/src/modules/offcanvas/index.css
+++ b/src/modules/offcanvas/index.css
@@ -1,3 +1,5 @@
+@import "fr-offcanvas/offcanvas.css";
+
 /** @define Offcanvas; */
 
 :root {

--- a/src/modules/offcanvas/index.js
+++ b/src/modules/offcanvas/index.js
@@ -2,12 +2,6 @@ import $ from 'jquery'
 
 import Froffcanvas from 'fr-offcanvas/offcanvas'
 
-/* eslint-disable no-unused-vars */
-
-import stylesheet from 'fr-offcanvas/offcanvas.css'
-
-/* eslint-enable */
-
 const opts = {
   // String - panel
   panelSelector: '.Offcanvas',

--- a/src/modules/skiplinks/index.css
+++ b/src/modules/skiplinks/index.css
@@ -1,3 +1,5 @@
+@import "fr-bypasslinks/bypasslinks.css";
+
 /** @define Skiplinks; weak */
 
 .Skiplinks {

--- a/src/modules/skiplinks/index.js
+++ b/src/modules/skiplinks/index.js
@@ -1,11 +1,5 @@
 import Frbypasslinks from 'fr-bypasslinks'
 
-/* eslint-disable no-unused-vars */
-
-import stylesheet from 'fr-bypasslinks/bypasslinks.css'
-
-/* eslint-enable */
-
 const bypassLinks = Frbypasslinks({
   selector: '.js-fr-bypasslinks'
 })

--- a/src/modules/tooltip/index.css
+++ b/src/modules/tooltip/index.css
@@ -1,3 +1,5 @@
+@import "fr-tooltip/tooltip.css";
+
 /** @define Tooltip */
 
 :root {

--- a/src/modules/tooltip/index.js
+++ b/src/modules/tooltip/index.js
@@ -1,11 +1,5 @@
 import Frtooltip from 'fr-tooltip'
 
-/* eslint-disable no-unused-vars */
-
-import stylesheet from 'fr-tooltip/tooltip.css'
-
-/* eslint-enable */
-
 const opts = {
   // String - Container selector, hook for JS init() method
   selector: '.js-fr-tooltip',

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -2,9 +2,8 @@ var webpack = require('webpack')
 var path = require('path')
 var libraryName = 'IWT'
 
-var ExtractTextPlugin = require('extract-text-webpack-plugin')
 var UglifyJsPlugin = webpack.optimize.UglifyJsPlugin
-  // var env = process.env.WEBPACK_ENV
+// var env = process.env.WEBPACK_ENV
 
 var plugins = []
 var loaders = []
@@ -17,12 +16,6 @@ loaders.push({
   test: /\.png/,
   loader: 'url-loader?limit=100000&minetype=image/png'
 })
-
-loaders.push({
-  test: /\.css$/,
-  loader: ExtractTextPlugin.extract('style-loader', 'css-loader')
-})
-plugins.push(new ExtractTextPlugin('vendor.css'))
 
 var config = {
   entry: {
@@ -45,7 +38,7 @@ var config = {
     loaders: [...loaders, {
       test: /(\.jsx|\.js)$/,
       loader: 'babel-loader',
-      //      exclude: /(node_modules|bower_components)/
+      // exclude: /(node_modules|bower_components)/
     }, {
       test: /(\.jsx|\.js)$/,
       loader: 'eslint-loader',


### PR DESCRIPTION
I file CSS di alcuni componenti di Frend.co erano compilati tramite webpack ed inclusi in vendor.css, mentre il resto dei CSS dei vendors era aggregato dal preprocessore di SuitCSS direttamente nel build.css. 
Ho eliminato questo doppio comportamento ed ora tutto è processato dal preprocessore di SuitCSS ed aggregato in build.css. Ilfile vendor.css è stato rimosso.