### PR TITLE
Rinominato .eslintrc ed aggiunto parametro 'root:true'

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+node_modules/**/*

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,8 +1,8 @@
-{
+module.exports = {
   "ecmaFeatures": {
     "globalReturn": true,
     "jsx": false,
-    "modules": true
+    "modules": true,
   },
   "rules": {
     "strict": 1,
@@ -42,6 +42,7 @@
     "expect": true,
     "sinon": true
   },
+  "root": true,
   "parser": "babel-eslint",
-  "plugins": [],
+  "plugins": []
 }


### PR DESCRIPTION
Per evitare possibili problemi durante la compilazione del toolkit in progetti dove fosse già presente eslint ho aggiunto all conf il paramentro root:true per impedire il parsing delle cartelle parents http://eslint.org/docs/user-guide/configuring#configuration-cascading-and-hierarchy. 